### PR TITLE
Feature/downloads versioning

### DIFF
--- a/app/controllers/download_controller.rb
+++ b/app/controllers/download_controller.rb
@@ -20,12 +20,12 @@ class DownloadController < ApplicationController
         )
         send_data csv.export,
           type: 'text/csv; charset=utf-8; header=present',
-          disposition: "attachment; filename=#{@context.country.name}_#{@context.commodity.name}.csv"
+          disposition: "attachment; filename=#{@context.country.name}_#{@context.commodity.name}_#{DownloadVersion.current_version_symbol}.csv"
       }
       format.json {
         send_data qb.flat_query.to_json,
           type: 'text/json; charset=utf-8',
-          disposition: "attachment; filename=#{@context.country.name}_#{@context.commodity.name}.json"
+          disposition: "attachment; filename=#{@context.country.name}_#{@context.commodity.name}_#{DownloadVersion.current_version_symbol}.json"
       }
     end
   end

--- a/app/models/download_version.rb
+++ b/app/models/download_version.rb
@@ -1,0 +1,6 @@
+class DownloadVersion < ApplicationRecord
+  def self.current_version_symbol
+    current_version = where(current: true).order('created_at DESC').first
+    current_version && current_version.symbol || 'UNKNOWN_VERSION'
+  end
+end

--- a/db/migrate/20170506225529_create_download_versions.rb
+++ b/db/migrate/20170506225529_create_download_versions.rb
@@ -1,0 +1,11 @@
+class CreateDownloadVersions < ActiveRecord::Migration[5.0]
+  def change
+    create_table :download_versions do |t|
+      t.string :symbol, null: false
+      t.boolean :current, default: false
+      t.timestamps
+    end
+    add_index :download_versions, :symbol, unique: true
+    DownloadVersion.create(symbol: '1.0', current: true)
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -453,6 +453,38 @@ ALTER SEQUENCE countries_country_id_seq OWNED BY countries.country_id;
 
 
 --
+-- Name: download_versions; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE download_versions (
+    id integer NOT NULL,
+    symbol character varying NOT NULL,
+    current boolean DEFAULT false,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: download_versions_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE download_versions_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: download_versions_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE download_versions_id_seq OWNED BY download_versions.id;
+
+
+--
 -- Name: flow_inds; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -1023,6 +1055,13 @@ ALTER TABLE ONLY countries ALTER COLUMN country_id SET DEFAULT nextval('countrie
 
 
 --
+-- Name: download_versions id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY download_versions ALTER COLUMN id SET DEFAULT nextval('download_versions_id_seq'::regclass);
+
+
+--
 -- Name: flows flow_id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -1153,6 +1192,14 @@ ALTER TABLE ONLY countries
 
 
 --
+-- Name: download_versions download_versions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY download_versions
+    ADD CONSTRAINT download_versions_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: flows flows_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -1213,6 +1260,13 @@ ALTER TABLE ONLY schema_migrations
 --
 
 CREATE UNIQUE INDEX context_indicators_indicator_attribute_type_indicator_attri_idx ON context_indicators USING btree (indicator_attribute_type, indicator_attribute_id, context_id);
+
+
+--
+-- Name: index_download_versions_on_symbol; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_download_versions_on_symbol ON download_versions USING btree (symbol);
 
 
 --
@@ -1516,6 +1570,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20170314115306'),
 ('20170316135218'),
 ('20170323090506'),
-('20170323121305');
+('20170323121305'),
+('20170506225529');
 
 

--- a/spec/controllers/download_controller_spec.rb
+++ b/spec/controllers/download_controller_spec.rb
@@ -5,30 +5,31 @@ RSpec.describe DownloadController, type: :controller do
   describe "GET index" do
     before(:each) do
       MaterializedFlow.refresh
+      FactoryGirl.create(:download_version, symbol: 'v1.0', current: true)
     end
     it "returns a csv file" do
       get :index, params: { context_id: context.id }, format: :csv
       expect(assigns(:context)).to eq(context)
       expect(response.content_type).to eq("text/csv")
-      expect(response.headers["Content-Disposition"]).to eq("attachment; filename=BRAZIL_SOY.csv")
+      expect(response.headers["Content-Disposition"]).to eq("attachment; filename=BRAZIL_SOY_v1.0.csv")
     end
     it "returns a csv file with pivot" do
       get :index, params: { context_id: context.id, pivot: 1 }, format: :csv
       expect(assigns(:context)).to eq(context)
       expect(response.content_type).to eq("text/csv")
-      expect(response.headers["Content-Disposition"]).to eq("attachment; filename=BRAZIL_SOY.csv")
+      expect(response.headers["Content-Disposition"]).to eq("attachment; filename=BRAZIL_SOY_v1.0.csv")
     end
     it "returns a semicolon-delimited csv file" do
       get :index, params: { context_id: context.id, separator: :semicolon}, format: :csv
       expect(assigns(:context)).to eq(context)
       expect(response.content_type).to eq("text/csv")
-      expect(response.headers["Content-Disposition"]).to eq("attachment; filename=BRAZIL_SOY.csv")
+      expect(response.headers["Content-Disposition"]).to eq("attachment; filename=BRAZIL_SOY_v1.0.csv")
     end
     it "returns a json file" do
       get :index, params: { context_id: context.id }, format: :json
       expect(assigns(:context)).to eq(context)
       expect(response.content_type).to eq("text/json")
-      expect(response.headers["Content-Disposition"]).to eq("attachment; filename=BRAZIL_SOY.json")
+      expect(response.headers["Content-Disposition"]).to eq("attachment; filename=BRAZIL_SOY_v1.0.json")
     end
   end
 end

--- a/spec/factories/download_version.rb
+++ b/spec/factories/download_version.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :download_version do
+    symbol { |n| "1.#{n}"}
+    current false
+  end
+end


### PR DESCRIPTION
Adds a table called download versions, which allows to add version symbols with timestamps the most recent version marked "current" will be appended to the name of the downloaded file.