### PR TITLE
Do not filter non-temporal indicator values by year for ranking

### DIFF
--- a/app/models/flow_stats_for_node.rb
+++ b/app/models/flow_stats_for_node.rb
@@ -104,7 +104,10 @@ class FlowStatsForNode
         'nodes.node_id',
         "DENSE_RANK() OVER (ORDER BY #{value_table}.value DESC) AS rank"
       ).
-      where("#{value_table}.year" => @year)
+      where(
+        "#{value_table}.year = ? OR NOT COALESCE(#{dict_table}.place_factsheet_temporal, FALSE)",
+        @year
+      )
 
     result = Node.from('(' + query.to_sql + ') s').
       select('s.*').

--- a/app/models/place_attributes.rb
+++ b/app/models/place_attributes.rb
@@ -153,7 +153,7 @@ EOT
       {type: 'ind', backend_name: 'PERC_INDIGENOUS'}, # NO MATCH
       {type: 'ind', backend_name: 'PERC_PROTECTED'}, # NO MATCH
       {type: 'quant', backend_name: 'EMBARGOES_'},
-      {type: 'ind', backend_name: 'COMPLIANCE_FOREST_CODE'}, # NO MATCH
+      {type: 'ind', backend_name: 'PROTECTED_DEFICIT_PERC'},
       {type: 'quant', backend_name: 'PROTECTED'} # NO MATCH
     ]
 

--- a/app/models/place_attributes.rb
+++ b/app/models/place_attributes.rb
@@ -150,11 +150,11 @@ EOT
   def other_indicators
     indicators_list = [
       {type: 'quant', backend_name: 'BIODIVERSITY'},
-      {type: 'ind', backend_name: 'PERC_INDIGENOUS'},
-      {type: 'ind', backend_name: 'PERC_PROTECTED'},
+      {type: 'ind', backend_name: 'PERC_INDIGENOUS'}, # NO MATCH
+      {type: 'ind', backend_name: 'PERC_PROTECTED'}, # NO MATCH
       {type: 'quant', backend_name: 'EMBARGOES_'},
-      {type: 'ind', backend_name: 'COMPLIANCE_FOREST_CODE'},
-      {type: 'quant', backend_name: 'PROTECTED'}
+      {type: 'ind', backend_name: 'COMPLIANCE_FOREST_CODE'}, # NO MATCH
+      {type: 'quant', backend_name: 'PROTECTED'} # NO MATCH
     ]
 
     indicators_group(indicators_list, 'Other environmental indicators')
@@ -304,14 +304,16 @@ EOT
 
   def indicators_group(list, name)
     # fetch frontend names and units
-    list.each do |indicator|
+    list = list.select do |indicator|
       i = indicator[:type].camelize.constantize.find_by_name(indicator[:backend_name])
       if i.nil?
         Rails.logger.debug "NOT FOUND " + indicator[:backend_name]
-        next
+        false
+      else
+        indicator[:name] = i.frontend_name
+        indicator[:unit] = i.unit
+        indicator
       end
-      indicator[:name] = i.frontend_name
-      indicator[:unit] = i.unit
     end
     included_columns = list.map{ |i| i.slice(:name, :unit)}
     values = []


### PR DESCRIPTION
I believe it helps with most indicators (e.g. water scarcity, fires), still need to check on some odd empty rows in "other environmental indicators" but this at least should sort out the default selected tab.

https://basecamp.com/1756858/projects/12498794/todos/308418561