### PR TITLE
Fix/indicators values from different years than selected

### DIFF
--- a/app/models/flow_stats_for_node.rb
+++ b/app/models/flow_stats_for_node.rb
@@ -93,7 +93,8 @@ class FlowStatsForNode
   # Returns the node's ranking across all nodes of same type within given state
   # for given indicator
   # for selected year
-  def state_ranking(state, indicator_type, indicator_name)
+  def state_ranking(state, indicator_type, indicator_name, year = nil)
+    year ||= @year
     value_table, dict_table = if indicator_type == 'quant'
       ['node_quants', 'quants']
     elsif indicator_type == 'ind'
@@ -107,7 +108,7 @@ class FlowStatsForNode
       ).
       where(
         "#{value_table}.year = ? OR NOT COALESCE(#{dict_table}.place_factsheet_temporal, FALSE)",
-        @year
+        year
       )
 
     result = Node.from('(' + query.to_sql + ') s').

--- a/app/models/ind.rb
+++ b/app/models/ind.rb
@@ -28,8 +28,4 @@ class Ind < ActiveRecord::Base
     has_many :context_recolor_bies, as: :recolor_attribute
     has_many :context_resize_bies, as: :resize_attribute
     has_many :context_indicators, as: :indicator
-
-    scope :place_temporal, -> {
-      where('place_factsheet AND place_factsheet_temporal')
-    }
 end

--- a/app/models/quant.rb
+++ b/app/models/quant.rb
@@ -28,11 +28,4 @@ class Quant < ActiveRecord::Base
     has_many :context_recolor_bies, as: :recolor_attribute
     has_many :context_resize_bies, as: :resize_attribute
     has_many :context_indicators, as: :indicator
-
-    scope :place_temporal, -> {
-      where("(place_factsheet AND place_factsheet_temporal) OR name IN ('AGROSATELITE_SOY_DEFOR_', 'DEFORESTATION_V2')")
-    }
-    scope :actor_temporal, -> {
-      where("(actor_factsheet AND actor_factsheet_temporal) OR name IN ('SOY_')")
-    }
 end


### PR DESCRIPTION
Place factsheet, sustainability indicators

This is a fix for https://basecamp.com/1756858/projects/12498794/todos/325645849

The source of the issue is twofold:
1. the "temporal" flag was not set correctly in the database, meaning a few indicators which should be temporal were treated as if their not and the value displayed in the table would be coming from one of the available years in a random manner. To fix the temporal flag on both actor and place profiles please use the SQL script below.
2. once the flag has been fixed, all the affected values (previously pulled randomly by the above incorrect behaviour) would now be empty (temporal + no value for 2015 - nothing displayed). The request was to keep displaying the value from closest year, with indication of the year this is for. To fix that there is now logic in place which does it in an intentional manner.

Expect changes to some of the values & ranking scores, hopefully for the better.

The year property was added to the API response, so that in case a value is pulled from a different year than selected the frontend can indicate it somehow (if year is same as selected the year attribute is not present).

<img width="398" alt="screen shot 2017-09-27 at 13 47 35" src="https://user-images.githubusercontent.com/134055/30914147-7bf4ceea-a38a-11e7-9201-2a2c1cd366f0.png">

Quants which are marked as not temporal but have values by year:
Place:
'AGROSATELITE_SOY_DEFOR_' (exception in API condition)
'EMBARGOES_'
'FIRES_'
'LAND_CONFL'
'POTENTIAL_SOY_DEFORESTATION_V2'
'SLAVERY'
Actor:
'DEFORESTATION_V2' (exception in API condition)
'AGROSATELITE_SOY_DEFOR_' (exception in API condition)
'SOY_' (exception in API condition)

Inds which are marked as not temporal but have values by year:
'GDP_CAP'
'PERC_FARM_GDP_'
'SOY_AREAPERC'
'SOY_YIELD'

FIXUP: mark them as temporal

```
WITH quants_with_year_values AS (
  SELECT distinct quants.quant_id
  FROM node_quants
  JOIN quants ON quants.quant_id = node_quants.quant_id
  WHERE place_factsheet AND (place_factsheet_temporal is null or not place_factsheet_temporal)
  AND year IS NOT NULL
)
UPDATE quants SET place_factsheet_temporal = true
FROM quants_with_year_values
WHERE quants_with_year_values.quant_id = quants.quant_id;

WITH inds_with_year_values AS (
  SELECT distinct inds.ind_id
  FROM node_inds
  JOIN inds ON inds.ind_id = node_inds.ind_id
  WHERE place_factsheet AND (place_factsheet_temporal is null or not place_factsheet_temporal)
  AND year IS NOT NULL
)
UPDATE inds SET place_factsheet_temporal = true
FROM inds_with_year_values
WHERE inds_with_year_values.ind_id = inds.ind_id;

WITH quants_with_year_values AS (
  SELECT distinct quants.quant_id
  FROM node_quants
  JOIN quants ON quants.quant_id = node_quants.quant_id
  WHERE actor_factsheet AND (actor_factsheet_temporal is null or not actor_factsheet_temporal)
  AND year IS NOT NULL
)
UPDATE quants SET actor_factsheet_temporal = true
FROM quants_with_year_values
WHERE quants_with_year_values.quant_id = quants.quant_id;

WITH inds_with_year_values AS (
  SELECT distinct inds.ind_id
  FROM node_inds
  JOIN inds ON inds.ind_id = node_inds.ind_id
  WHERE actor_factsheet AND (actor_factsheet_temporal is null or not actor_factsheet_temporal)
  AND year IS NOT NULL
)
UPDATE inds SET place_factsheet_temporal = true
FROM inds_with_year_values
WHERE inds_with_year_values.ind_id = inds.ind_id;
```