### PR TITLE
Sources ranked by trade volume for display in the sustainability indi…

### DIFF
--- a/app/models/actor_attributes.rb
+++ b/app/models/actor_attributes.rb
@@ -288,7 +288,7 @@ EOT
   def sustainability_for_group(name, node_type, include_totals)
     group_totals_hash = Hash.new
     top_nodes_in_group = FlowStatsForNode.new(@context, @year, @node, node_type).
-      top_nodes_for_quant('DEFORESTATION_V2') # TODO should this not be Volume?
+      top_nodes_for_quant('Volume')
     rows = top_nodes_in_group.map do |node|
       top_node = Node.find(node['node_id'])
       totals_per_indicator = (top_node.actor_quants + top_node.temporal_actor_quants(@year))


### PR DESCRIPTION
This is a fix for https://basecamp.com/1756858/projects/12498794/todos/325652739

The problem is the list of top sourcing regions in the line chart
<img width="623" alt="screen shot 2017-09-27 at 14 25 07" src="https://user-images.githubusercontent.com/134055/30915897-fde20a26-a38f-11e7-8201-6fa41391c875.png">

shows a rather different list of regions than the sustainability indicators sections, where logically these should be the same regions in same order. That was caused by (possibly?) accidental application of completely wrong quant to the calculation.

<img width="1099" alt="screen shot 2017-09-27 at 14 25 18" src="https://user-images.githubusercontent.com/134055/30916052-5054ad72-a390-11e7-9f20-ec45c7c6aa67.png">

