### PR TITLE
Importer summary + refactored exporter summary

### DIFF
--- a/app/models/node.rb
+++ b/app/models/node.rb
@@ -226,4 +226,19 @@ class Node < ActiveRecord::Base
       joins(node_quals: :qual).
       where('node_quals.value' => state.name, 'quals.name' => 'STATE')
   end
+
+  def flow_values(context, indicator_type, indicator_name)
+    node_index = NodeType.node_index_for_id(context, self.node_type_id)
+    value_table, dict_table = if indicator_type == 'quant'
+      ['flow_quants', 'quants']
+    elsif indicator_type == 'ind'
+      ['flow_inds', 'inds']
+    end
+    Flow.
+      joins("JOIN #{value_table} ON flows.flow_id = #{value_table}.flow_id").
+      joins("JOIN #{dict_table} ON #{dict_table}.#{indicator_type}_id = #{value_table}.#{indicator_type}_id").
+      where("#{dict_table}.name" => indicator_name).
+      where('path[?] = ?', node_index, self.id).
+      where(context_id: context.id)
+  end
 end


### PR DESCRIPTION
Adds importer summary as discussed here:

https://basecamp.com/1756858/projects/12498794/todos/321177482

Important thing is: both summaries now use flows data (Volume quant) rather than quant data (SOY_ quant) to calculate the numbers of tons and derived values; I have checked that the calculated values for exporters / importers match those that were pre-calculated. This does NOT yet remove dependency on the SOY_ quant entirely, as it is still used in other places.

Bunge exporter:
```
Bunge was the largest exporter of soy in BRAZIL in 2015, accounting for 11,548 thousand tons. This is a 9% decrease vs the previous year. As an exporter, Bunge sources from 835 municipalities, or 40% of the soy production municipalities. The main destination of the soy exportered by Bunge is China, accounting for 48% of the total.
```

Bunge importer:
```
Bunge was the largest importer of soy in BRAZIL in 2015, accounting for 12,044 thousand tons. This is a 13% decrease vs the previous year. As an importer, Bunge sources from 916 municipalities, or 44% of the soy production municipalities. The main destination of the soy importered by Bunge is China, accounting for 46% of the total.
```
