### PR TITLE
Changes column name from type to original_type

### DIFF
--- a/db/migrate/20171101111009_rename_type_to_original_type.rb
+++ b/db/migrate/20171101111009_rename_type_to_original_type.rb
@@ -1,0 +1,67 @@
+class RenameTypeToOriginalType < ActiveRecord::Migration[5.0]
+  include SearchPathHelpers
+
+  def up
+    with_search_path('revamp') do
+      drop_dependent_views
+
+      update_view :attributes_mv,
+        version: 2,
+        revert_to_version: 1,
+        materialized: true
+
+      create_dependent_mviews(2)
+    end
+  end
+
+  def down
+    with_search_path('revamp') do
+      drop_dependent_views
+
+      update_view :attributes_mv,
+        version: 1,
+        revert_to_version: 1,
+        materialized: true
+
+      create_dependent_mviews(1)
+    end
+  end
+
+  def drop_dependent_views
+    drop_view :download_attributes_mv, materialized: true
+    drop_view :map_attributes_mv, materialized: true
+    drop_view :resize_by_attributes_mv, materialized: true
+    drop_view :recolor_by_attributes_mv, materialized: true
+  end
+
+  def create_dependent_mviews(version)
+      create_view :download_attributes_mv,
+        version: version,
+        materialized: true
+      add_index :download_attributes_mv, :id, unique: true,
+        name: 'download_attributes_mv_id_idx'
+      add_index :download_attributes_mv, [:context_id, :attribute_id],
+        name: 'download_attributes_mv_context_id_attribute_id_idx'
+      create_view :resize_by_attributes_mv,
+        version: version,
+        materialized: true
+      add_index :resize_by_attributes_mv, :id, unique: true,
+        name: 'resize_by_attributes_mv_id_idx'
+      add_index :resize_by_attributes_mv, [:context_id, :attribute_id],
+        name: 'resize_by_attributes_mv_context_id_attribute_id_idx'
+      create_view :recolor_by_attributes_mv,
+        version: version,
+        materialized: true
+      add_index :recolor_by_attributes_mv, :id, unique: true,
+        name: 'recolor_by_attributes_mv_id_idx'
+      add_index :recolor_by_attributes_mv, [:context_id, :attribute_id],
+        name: 'recolor_by_attributes_mv_context_id_attribute_id'
+      create_view :map_attributes_mv,
+        version: version,
+        materialized: true
+      add_index :map_attributes_mv, :id, unique: true,
+        name: 'map_attributes_mv_id_idx'
+      add_index :map_attributes_mv, [:map_attribute_group_id, :attribute_id],
+        name: 'map_attributes_mv_map_attribute_group_id_attribute_id_idx'
+  end
+end

--- a/db/schema_comments.yml
+++ b/db/schema_comments.yml
@@ -36,7 +36,7 @@ tables:
     comment: Commodities in supply chains, such as soy or beef
     columns:
       - name: name
-        comment: Commodity name; unique across commodities # TODO
+        comment: Commodity name; unique across commodities
       - name: parent_id
         comment: Self-reference to parent used to define links between commodities and sub-commodities
   - name: context_node_types
@@ -306,10 +306,10 @@ materialized_views:
     columns:
       - name: id
         comment: The unique id is a sequential number which is generated at REFRESH and therefore not fixed.
-      - name: type
+      - name: original_type
         comment: Type of the original entity (Ind / Qual / Quant)
       - name: original_id
-        comment: Id from the source table (inds / quals / quants)
+        comment: Id from the original table (inds / quals / quants)
   - name: download_attributes_mv
     comment: Materialized view which merges download_quals and download_quants with download_attributes.
     columns:

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1216,7 +1216,7 @@ COMMENT ON COLUMN quants.tooltip_text IS 'Tooltip text';
 
 CREATE MATERIALIZED VIEW attributes_mv AS
  SELECT row_number() OVER () AS id,
-    s.type,
+    s.original_type,
     s.original_id,
     s.name,
     s.display_name,
@@ -1227,7 +1227,7 @@ CREATE MATERIALIZED VIEW attributes_mv AS
     s.aggregate_method,
     s.created_at,
     s.updated_at
-   FROM ( SELECT 'Quant'::text AS type,
+   FROM ( SELECT 'Quant'::text AS original_type,
             quants.id AS original_id,
             quants.name,
             quants.display_name,
@@ -1241,20 +1241,20 @@ CREATE MATERIALIZED VIEW attributes_mv AS
            FROM quants
         UNION ALL
          SELECT 'Ind'::text,
-            inds.id AS original_id,
+            inds.id,
             inds.name,
             inds.display_name,
             inds.unit,
             inds.unit_type,
             inds.tooltip,
             inds.tooltip_text,
-            'AVG'::text AS aggregate_method,
+            'AVG'::text,
             inds.created_at,
             inds.updated_at
            FROM inds
         UNION ALL
          SELECT 'Qual'::text,
-            quals.id AS original_id,
+            quals.id,
             quals.name,
             quals.display_name,
             NULL::text,
@@ -1283,17 +1283,17 @@ COMMENT ON COLUMN attributes_mv.id IS 'The unique id is a sequential number whic
 
 
 --
--- Name: COLUMN attributes_mv.type; Type: COMMENT; Schema: revamp; Owner: -
+-- Name: COLUMN attributes_mv.original_type; Type: COMMENT; Schema: revamp; Owner: -
 --
 
-COMMENT ON COLUMN attributes_mv.type IS 'Type of the original entity (Ind / Qual / Quant)';
+COMMENT ON COLUMN attributes_mv.original_type IS 'Type of the original entity (Ind / Qual / Quant)';
 
 
 --
 -- Name: COLUMN attributes_mv.original_id; Type: COMMENT; Schema: revamp; Owner: -
 --
 
-COMMENT ON COLUMN attributes_mv.original_id IS 'Id from the source table (inds / quals / quants)';
+COMMENT ON COLUMN attributes_mv.original_id IS 'Id from the original table (inds / quals / quants)';
 
 
 --
@@ -2097,7 +2097,7 @@ CREATE MATERIALIZED VIEW download_attributes_mv AS
     a.id AS attribute_id
    FROM ((download_quants daq
      JOIN download_attributes da ON ((da.id = daq.download_attribute_id)))
-     JOIN attributes_mv a ON (((a.original_id = daq.quant_id) AND (a.type = 'Quant'::text))))
+     JOIN attributes_mv a ON (((a.original_id = daq.quant_id) AND (a.original_type = 'Quant'::text))))
 UNION ALL
  SELECT da.id,
     da.context_id,
@@ -2109,7 +2109,7 @@ UNION ALL
     a.id AS attribute_id
    FROM ((download_quals daq
      JOIN download_attributes da ON ((da.id = daq.download_attribute_id)))
-     JOIN attributes_mv a ON (((a.original_id = daq.qual_id) AND (a.type = 'Qual'::text))))
+     JOIN attributes_mv a ON (((a.original_id = daq.qual_id) AND (a.original_type = 'Qual'::text))))
   WITH NO DATA;
 
 
@@ -2640,7 +2640,7 @@ CREATE MATERIALIZED VIEW map_attributes_mv AS
     a.id AS attribute_id
    FROM ((map_quants maq
      JOIN map_attributes ma ON ((ma.id = maq.map_attribute_id)))
-     JOIN attributes_mv a ON (((a.original_id = maq.quant_id) AND (a.type = 'Quant'::text))))
+     JOIN attributes_mv a ON (((a.original_id = maq.quant_id) AND (a.original_type = 'Quant'::text))))
 UNION ALL
  SELECT ma.id,
     ma.map_attribute_group_id,
@@ -2656,7 +2656,7 @@ UNION ALL
     a.id AS attribute_id
    FROM ((map_inds mai
      JOIN map_attributes ma ON ((ma.id = mai.map_attribute_id)))
-     JOIN attributes_mv a ON (((a.original_id = mai.ind_id) AND (a.type = 'Ind'::text))))
+     JOIN attributes_mv a ON (((a.original_id = mai.ind_id) AND (a.original_type = 'Ind'::text))))
   WITH NO DATA;
 
 
@@ -3275,7 +3275,7 @@ CREATE MATERIALIZED VIEW recolor_by_attributes_mv AS
     a.id AS attribute_id
    FROM ((recolor_by_inds rai
      JOIN recolor_by_attributes ra ON ((ra.id = rai.recolor_by_attribute_id)))
-     JOIN attributes_mv a ON (((a.original_id = rai.ind_id) AND (a.type = 'Ind'::text))))
+     JOIN attributes_mv a ON (((a.original_id = rai.ind_id) AND (a.original_type = 'Ind'::text))))
 UNION ALL
  SELECT ra.id,
     ra.context_id,
@@ -3296,7 +3296,7 @@ UNION ALL
     a.id AS attribute_id
    FROM ((recolor_by_quals raq
      JOIN recolor_by_attributes ra ON ((ra.id = raq.recolor_by_attribute_id)))
-     JOIN attributes_mv a ON (((a.original_id = raq.qual_id) AND (a.type = 'Qual'::text))))
+     JOIN attributes_mv a ON (((a.original_id = raq.qual_id) AND (a.original_type = 'Qual'::text))))
   WITH NO DATA;
 
 
@@ -3476,7 +3476,7 @@ CREATE MATERIALIZED VIEW resize_by_attributes_mv AS
     a.id AS attribute_id
    FROM ((resize_by_quants raq
      JOIN resize_by_attributes ra ON ((ra.id = raq.resize_by_attribute_id)))
-     JOIN attributes_mv a ON (((a.original_id = raq.quant_id) AND (a.type = 'Quant'::text))))
+     JOIN attributes_mv a ON (((a.original_id = raq.quant_id) AND (a.original_type = 'Quant'::text))))
   WITH NO DATA;
 
 
@@ -5939,6 +5939,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20171018093008'),
 ('20171020091710'),
 ('20171020125731'),
-('20171020133529');
+('20171020133529'),
+('20171101111009');
 
 

--- a/db/views/attributes_mv_v02.sql
+++ b/db/views/attributes_mv_v02.sql
@@ -1,0 +1,47 @@
+SELECT ROW_NUMBER() OVER () AS id, * FROM (
+  SELECT
+    'Quant' AS original_type,
+    id AS original_id,
+    name,
+    display_name,
+    unit,
+    unit_type,
+    tooltip,
+    tooltip_text,
+    'SUM' AS aggregate_method,
+    created_at,
+    updated_at
+  FROM quants
+
+  UNION ALL
+
+  SELECT
+    'Ind',
+    id,
+    name,
+    display_name,
+    unit,
+    unit_type,
+    tooltip,
+    tooltip_text,
+    'AVG',
+    created_at,
+    updated_at
+  FROM inds
+
+  UNION ALL
+
+  SELECT
+    'Qual',
+    id,
+    name,
+    display_name,
+    NULL,
+    NULL,
+    tooltip,
+    tooltip_text,
+    NULL,
+    created_at,
+    updated_at
+  FROM quals
+) s;

--- a/db/views/download_attributes_mv_v02.sql
+++ b/db/views/download_attributes_mv_v02.sql
@@ -1,0 +1,11 @@
+SELECT da.*, a.id AS attribute_id
+FROM download_quants daq
+JOIN download_attributes da ON da.id = daq.download_attribute_id
+JOIN attributes_mv a ON a.original_id = daq.quant_id AND a.original_type = 'Quant'
+
+UNION ALL
+
+SELECT da.*, a.id AS attribute_id
+FROM download_quals daq
+JOIN download_attributes da ON da.id = daq.download_attribute_id
+JOIN attributes_mv a ON a.original_id = daq.qual_id AND a.original_type = 'Qual'

--- a/db/views/map_attributes_mv_v02.sql
+++ b/db/views/map_attributes_mv_v02.sql
@@ -1,0 +1,11 @@
+SELECT ma.*, a.id AS attribute_id
+FROM map_quants maq
+JOIN map_attributes ma ON ma.id = maq.map_attribute_id
+JOIN attributes_mv a ON a.original_id = maq.quant_id AND a.original_type = 'Quant'
+
+UNION ALL
+
+SELECT ma.*, a.id AS attribute_id
+FROM map_inds mai
+JOIN map_attributes ma ON ma.id = mai.map_attribute_id
+JOIN attributes_mv a ON a.original_id = mai.ind_id AND a.original_type = 'Ind'

--- a/db/views/recolor_by_attributes_mv_v02.sql
+++ b/db/views/recolor_by_attributes_mv_v02.sql
@@ -1,0 +1,11 @@
+SELECT ra.*, a.id AS attribute_id
+FROM recolor_by_inds rai
+JOIN recolor_by_attributes ra ON ra.id = rai.recolor_by_attribute_id
+JOIN attributes_mv a ON a.original_id = rai.ind_id AND a.original_type = 'Ind'
+
+UNION ALL
+
+SELECT ra.*, a.id AS attribute_id
+FROM recolor_by_quals raq
+JOIN recolor_by_attributes ra ON ra.id = raq.recolor_by_attribute_id
+JOIN attributes_mv a ON a.original_id = raq.qual_id AND a.original_type = 'Qual'

--- a/db/views/resize_by_attributes_mv_v02.sql
+++ b/db/views/resize_by_attributes_mv_v02.sql
@@ -1,0 +1,4 @@
+SELECT ra.*, a.id AS attribute_id
+FROM resize_by_quants raq
+JOIN resize_by_attributes ra ON ra.id = raq.resize_by_attribute_id
+JOIN attributes_mv a ON a.original_id = raq.quant_id AND a.original_type = 'Quant'

--- a/lib/tasks/db_revamp_copy.rake
+++ b/lib/tasks/db_revamp_copy.rake
@@ -1,5 +1,10 @@
 namespace :db do
   namespace :revamp do
+    desc 'Refresh materialized views'
+    task refresh: [:environment] do
+      refresh_materialized_views
+    end
+
     desc 'Copy data from public schema into revamp schema'
     task copy: [:environment] do
       [
@@ -38,13 +43,17 @@ namespace :db do
       end
       populate_contextual_layers
       populate_profiles
-      refresh_materialized_view('attributes_mv')
-      refresh_materialized_view('map_attributes_mv')
-      refresh_materialized_view('recolor_by_attributes_mv')
-      refresh_materialized_view('resize_by_attributes_mv')
-      refresh_materialized_view('download_attributes_mv')
+      refresh_materialized_views
     end
   end
+end
+
+def refresh_materialized_views
+  refresh_materialized_view('attributes_mv')
+  refresh_materialized_view('map_attributes_mv')
+  refresh_materialized_view('recolor_by_attributes_mv')
+  refresh_materialized_view('resize_by_attributes_mv')
+  refresh_materialized_view('download_attributes_mv')
 end
 
 def truncate_table(table)


### PR DESCRIPTION
I made the mistake of calling a column in `attributes_mv` materialized view `type`, because originally that mview was a table and I thought this might be useful for an STI scenario with Qual / Quant / Ind inheriting from Attribute. Because of later changes this idea became obsolete and having a column called `type` became very problematic for Rails reasons, so this fixes it by renaming to `original_type` which goes well with `original_id`. I had to redefine all the `xxx_attributes_mv` as well, as this is a joining column.